### PR TITLE
Added the ability to define excluded extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ function strictify(file, opts) {
   return stream;
 
   function write(buf) {
-    if (!applied) {
+    if (!applied && (opts.exclude || []).indexOf(
+          path.extname(file).replace(".", "")) < 0) {
       stream.queue('"use strict";\n');
       applied = true;
     }

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 var util = require('util');
 var through = require('through');
+var path = require("path");
 
 function strictify(file, opts) {
   opts = opts || {};

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var util = require('util');
 var through = require('through');
-var path = require("path");
+var path = require('path');
 
 function strictify(file, opts) {
   opts = opts || {};

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function strictify(file, opts) {
 
   function write(buf) {
     if (!applied && (opts.exclude || []).indexOf(
-          path.extname(file).replace(".", "")) < 0) {
+          path.extname(file).replace('.', '')) < 0) {
       stream.queue('"use strict";\n');
       applied = true;
     }


### PR DESCRIPTION
If we define an excluded array with extensions in the options object then the
transformation will check if the file to transform have it, in which
case it will ignore it completely.
