### PR TITLE
Added option "newline"

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ function doStuff() {
 # opts
 
 `exclude`: array of file extensions to exclude. defaults to `['json']`
+`newline`: boolean to append a newline after "use strict". defaults to `true`
 
 # install
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ function doStuff() {
 # opts
 
 `exclude`: array of file extensions to exclude. defaults to `['json']`
-`newline`: boolean to append a newline after "use strict". defaults to `true`
+`newline`: boolean to append a newline after "use strict". defaults to `false`
 
 # install
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ function strictify(file, opts) {
   opts = opts || {};
   opts.exclude = ['json'].concat(opts.exclude||[]);
 
-  var tail = opts.newline !== false ? '\n' : '';
+  var tail = opts.newline ? '\n' : '';
 
   var stream = through(write, end);
   var applied = false;

--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ function strictify(file, opts) {
   opts = opts || {};
   opts.exclude = ['json'].concat(opts.exclude||[]);
 
+  var tail = opts.newline !== false ? '\n' : '';
+
   var stream = through(write, end);
   var applied = false;
 
@@ -20,7 +22,7 @@ function strictify(file, opts) {
 
   function write(buf) {
     if (!applied && !excluded) {
-      stream.queue('"use strict";\n');
+      stream.queue('"use strict";'+tail);
       applied = true;
     }
     stream.queue(buf);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strictify",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "browserify v2 plugin for enforcing strict mode",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Sometimes, you don't want to add an extra line, as it can mess up the source maps, and to maintain a consistent line number across the source and the bundled files. This also relates to https://github.com/jsdf/strictify/issues/3.
